### PR TITLE
fix(on_photo): ignore auto-forwarded channel posts in discussion groups

### DIFF
--- a/internal/handlers/on_photo/on_photo.go
+++ b/internal/handlers/on_photo/on_photo.go
@@ -299,6 +299,10 @@ func formatContext(o photoOrigin) string {
 func extractPhotoOrigin(msg *telebot.Message, sender *telebot.User) photoOrigin {
 	o := photoOrigin{Author: formatAuthor(sender)}
 
+	if msg.AutomaticForward {
+		return o
+	}
+
 	if msg.OriginalChat != nil {
 		if name := channelDisplay(msg.OriginalChat); name != "" {
 			o.ForwardedFromChannel = name

--- a/internal/handlers/on_photo/on_photo_test.go
+++ b/internal/handlers/on_photo/on_photo_test.go
@@ -550,6 +550,46 @@ func TestExtractPhotoOrigin_OriginalChatCollapsesToEmpty_NoTrailingPreposition(t
 	assert.NotContains(t, ctx, "переслано из канала")
 }
 
+func TestExtractPhotoOrigin_AutomaticForward_IgnoresForwardedFromChannel(t *testing.T) {
+	t.Parallel()
+
+	sender := &telebot.User{ID: 7, FirstName: "Alice", Username: "alice"}
+	msg := &telebot.Message{
+		ID:    1,
+		Photo: &telebot.Photo{},
+		OriginalChat: &telebot.Chat{
+			Type:     telebot.ChatChannel,
+			Username: "memes",
+			Title:    "Memes Channel",
+		},
+		AutomaticForward: true,
+	}
+
+	got := extractPhotoOrigin(msg, sender)
+
+	assert.Empty(t, got.ForwardedFromChannel)
+	assert.Empty(t, got.ForwardedFromUser)
+	assert.Equal(t, "@alice", got.Author)
+}
+
+func TestExtractPhotoOrigin_AutomaticForward_IgnoresOriginalSender(t *testing.T) {
+	t.Parallel()
+
+	sender := &telebot.User{ID: 7, FirstName: "Alice", Username: "alice"}
+	msg := &telebot.Message{
+		ID:               1,
+		Photo:            &telebot.Photo{},
+		OriginalSender:   &telebot.User{ID: 8, FirstName: "Вася", Username: "vasya"},
+		AutomaticForward: true,
+	}
+
+	got := extractPhotoOrigin(msg, sender)
+
+	assert.Empty(t, got.ForwardedFromChannel)
+	assert.Empty(t, got.ForwardedFromUser)
+	assert.Equal(t, "@alice", got.Author)
+}
+
 func TestExtractPhotoOrigin_OriginalChatEmpty_FallsThroughToOriginalSender(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Telegram outsmarts us: a channel post automatically mirrored into the linked discussion group arrives with forward_from_chat set to the same channel. extractPhotoOrigin treated this as "this is a repost from channel @X" and the LLM dutifully framed responses that way. Use the is_automatic_forward flag (Message.AutomaticForward in telebot.v3) to skip forward-context extraction in exactly that case. Regular chats and real manual forwards from a channel are unaffected — they come in with AutomaticForward=false.